### PR TITLE
Created application initializer for setting base URL for AJAX calls

### DIFF
--- a/frontend/app/initializers/ajax-override.js
+++ b/frontend/app/initializers/ajax-override.js
@@ -1,0 +1,52 @@
+/*global jQuery */
+import ENV from '../config/environment';
+ 
+export function initialize(/* application */) {
+	if (ENV.APP.usingCors) {
+		(function($) {
+			var _old = $.ajax;
+			$.ajax = function() {
+				var url, settings, apiURL = ENV.APP.apiURL;
+ 
+				/* Handle the different function signatures available for $.ajax() */
+				if (arguments.length === 2) {
+					url = arguments[0];
+					settings = arguments[1];
+				} else {
+					settings = arguments[0];
+				}
+ 
+				settings.crossDomain = true;
+				if (!settings.xhrFields) {
+					settings.xhrFields = {};
+				}
+				settings.xhrFields.withCredentials = true;
+ 
+				if (!url) {
+					url = settings.url;
+				}
+ 
+				/* If we still don't have an URL, execute the request and let jQuery handle it */
+				if (!url) {
+					return _old.apply(this, [settings]);
+				}
+ 
+				/* combine the apiURL and the url request if necessary */
+				if (!url.includes(apiURL)) {
+					/* Do we need a '/'? */
+					if (url[0] !== '/' && apiURL[apiURL.length-1] !== '/') {
+						url = '/' + url;
+					}
+					url = apiURL + url;
+				}
+				settings.url = url;
+ 
+				return _old.apply(this, [settings]);
+			};
+		})(jQuery);
+	}}
+
+export default {
+  name: 'ajax-override',
+  initialize
+};

--- a/frontend/tests/unit/initializers/ajax-override-test.js
+++ b/frontend/tests/unit/initializers/ajax-override-test.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import { initialize } from 'pslab-frontend/initializers/ajax-override';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Initializer | ajax override', {
+  beforeEach() {
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.application.deferReadiness();
+    });
+  },
+  afterEach() {
+    destroyApp(this.application);
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(this.application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});


### PR DESCRIPTION
fixes #45. already fixed #4 , #7 , #41 
All AJAX calls will now respect the hostAPI variable configured in config/environment.js , and send requests to the correct API server.