### PR TITLE
Added API methods for common example script retrieval and execution

### DIFF
--- a/app/scripts/plot_test.py
+++ b/app/scripts/plot_test.py
@@ -1,0 +1,10 @@
+import numpy as np
+x=np.linspace(0,2*np.pi,30)
+plt = plot(x, np.sin(x))
+button('capture 1',"capture1('CH1',100,10)","update-plot",target=plt)
+
+plt2 = plot(x, np.sin(x))
+button('capture 2',"capture2(50,10)","update-plot",target=plt2,stacking='xyy')
+
+plt3 = plot(x, np.sin(x))
+button('capture 4',"capture4(50,10)","update-plot",target=plt3,stacking='xyyyy')

--- a/app/views.py
+++ b/app/views.py
@@ -171,7 +171,7 @@ def deleteScript():
 
 
 @app.route('/getCommonScripts')
-def getScriptList():
+def getCommonScripts():
 	try:
 		if session.get('user'):
 			_user = session.get('user')[1]
@@ -185,7 +185,7 @@ def getScriptList():
 
 
 @app.route('/getScriptByFilename',methods=['POST'])
-def getCodeById():
+def getScriptByFilename():
 	if session.get('user'):
 		try:
 			Filename = request.form['Filename']
@@ -193,13 +193,13 @@ def getCodeById():
 				data=myfile.read()
 			return json.dumps({'status':True,'Filename':Filename,'Code':data})
 		except Exception as exc:
-			return json.dumps({'data':None,'status':False,'message':str(exc)})
+			return json.dumps({'status':False,'message':str(exc),'Code':None})
 	else:
-		return json.dumps({'data':None,'status':False,'message':'Unauthorized access'})
+		return json.dumps({'status':False,'message':'Unauthorized access','Code':None})
 
 
 @app.route('/runScriptByFilename',methods=['POST'])
-def getCodeById():
+def runScriptByFilename():
 	if session.get('user'):
 		try:
 			Filename = request.form['Filename']

--- a/app/views.py
+++ b/app/views.py
@@ -109,11 +109,9 @@ def getScriptList():
 						'Date': script.pub_date,
 						'readonly':False}
 				scripts_dict.append(single_script)
-			
 			for a in os.listdir('./app/scripts'):
 				if a[-3:]=='.py':
 					scripts_dict.append({'Filename':a,'readonly':True})
-			
 			return json.dumps(scripts_dict)
 		else:
 			return json.dumps([])

--- a/app/views.py
+++ b/app/views.py
@@ -190,21 +190,6 @@ def getScriptByFilename():
 		return json.dumps({'status':False,'message':'Unauthorized access','Code':None})
 
 
-@app.route('/runScriptByFilename',methods=['POST'])
-def runScriptByFilename():
-	if session.get('user'):
-		try:
-			Filename = request.form['Filename']
-			with open ('./app/scripts/'+Filename, "r") as myfile:
-				data=myfile.read()
-			res = myEval.runCode(script.code)
-			return json.dumps({'status':True,'Filename':Filename,'result':res})
-		except Exception as exc:
-			return json.dumps({'result':None,'status':False,'message':str(exc)})
-	else:
-		return json.dumps({'result':None,'status':False,'message':'Unauthorized access'})
-
-
 
 
 
@@ -256,7 +241,7 @@ def evalFunctionString():
 @app.route('/runScriptById',methods=['POST'])
 def runScriptById():
 	if session.get('user'):
-		_id = request.form['id']
+		_id = request.form['Id']
 		_user = session.get('user')[1]
 		try:
 			script = UserCode.query.filter_by(user=_user,id=_id).first()
@@ -266,5 +251,20 @@ def runScriptById():
 			return json.dumps({'status':False,'result':str(exc)})
 	else:
 		return json.dumps({'status':False,'result':'unauthorized access','message':'Unauthorized access'})
+
+
+@app.route('/runScriptByFilename',methods=['POST'])
+def runScriptByFilename():
+	if session.get('user'):
+		try:
+			Filename = request.form['Filename']
+			with open ('./app/scripts/'+Filename, "r") as myfile:
+				data=myfile.read()
+			res = myEval.runCode(data)
+			return json.dumps({'status':True,'result':res})
+		except Exception as exc:
+			return json.dumps({'status':False,'result':None,'message':str(exc)})
+	else:
+		return json.dumps({'status':False,'result':None,'message':'Unauthorized access'})
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -116,7 +116,6 @@ def getScriptList():
 		return json.dumps([])
 
 
-
 @app.route('/getScriptById',methods=['POST'])
 def getCodeById():
 	if session.get('user'):
@@ -169,6 +168,51 @@ def deleteScript():
       return json.dumps({'status':False,'message':str(exc)})
   else:
     return json.dumps({'status':False,'message':'Unauthorized access'})
+
+
+@app.route('/getCommonScripts')
+def getScriptList():
+	try:
+		if session.get('user'):
+			_user = session.get('user')[1]
+			scripts = [{'Filename':a} for a in os.listdir('./app/scripts') if a[-3:]=='.py']
+			return json.dumps(scripts)
+		else:
+			return json.dumps([])
+	except Exception as e:
+		print (str(e))
+		return json.dumps([])
+
+
+@app.route('/getScriptByFilename',methods=['POST'])
+def getCodeById():
+	if session.get('user'):
+		try:
+			Filename = request.form['Filename']
+			with open ('./app/scripts/'+Filename, "r") as myfile:
+				data=myfile.read()
+			return json.dumps({'status':True,'Filename':Filename,'Code':data})
+		except Exception as exc:
+			return json.dumps({'data':None,'status':False,'message':str(exc)})
+	else:
+		return json.dumps({'data':None,'status':False,'message':'Unauthorized access'})
+
+
+@app.route('/runScriptByFilename',methods=['POST'])
+def getCodeById():
+	if session.get('user'):
+		try:
+			Filename = request.form['Filename']
+			with open ('./app/scripts/'+Filename, "r") as myfile:
+				data=myfile.read()
+			res = myEval.runCode(script.code)
+			return json.dumps({'status':True,'Filename':Filename,'result':res})
+		except Exception as exc:
+			return json.dumps({'result':None,'status':False,'message':str(exc)})
+	else:
+		return json.dumps({'result':None,'status':False,'message':'Unauthorized access'})
+
+
 
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -106,8 +106,14 @@ def getScriptList():
 						'Id': script.id,
 						'Filename': script.title,
 						#'Code': script.code, #Can be enbled if the user demands all scripts and content.
-						'Date': script.pub_date}
+						'Date': script.pub_date,
+						'readonly':False}
 				scripts_dict.append(single_script)
+			
+			for a in os.listdir('./app/scripts'):
+				if a[-3:]=='.py':
+					scripts_dict.append({'Filename':a,'readonly':True})
+			
 			return json.dumps(scripts_dict)
 		else:
 			return json.dumps([])
@@ -168,20 +174,6 @@ def deleteScript():
       return json.dumps({'status':False,'message':str(exc)})
   else:
     return json.dumps({'status':False,'message':'Unauthorized access'})
-
-
-@app.route('/getCommonScripts')
-def getCommonScripts():
-	try:
-		if session.get('user'):
-			_user = session.get('user')[1]
-			scripts = [{'Filename':a} for a in os.listdir('./app/scripts') if a[-3:]=='.py']
-			return json.dumps(scripts)
-		else:
-			return json.dumps([])
-	except Exception as e:
-		print (str(e))
-		return json.dumps([])
 
 
 @app.route('/getScriptByFilename',methods=['POST'])

--- a/frontend/app/templates/user-home.hbs
+++ b/frontend/app/templates/user-home.hbs
@@ -60,28 +60,30 @@
               <br>
 
               {{#each model as |script|}}
-                <li class="list-group-item">
-                  <div class="pull-left action-buttons">
-                    <a {{action 'executeScript' script on="click"}} role="button">
-                      <span class="glyphicon glyphicon-step-forward"></span>
-                    </a>
-                  </div>
-                  <div class="checkbox">
-                    <label>
-                      {{script.Filename}}
-                    </label>
-                  </div>
-                  <div class="pull-right action-buttons">
-                    <a {{action "openEditModal" script on="click"}} role="button">
-                      <span class="glyphicon glyphicon-pencil"></span>
-                    </a>
-                    <a {{action 'showDeleteDialog' script on="click"}} role="button">
-                      <span class="glyphicon glyphicon-trash"></span>
-                    </a>
-                  </div>
-                </li>
+                {{#unless script.readonly}}
+                  <li class="list-group-item">
+		                  <div class="pull-left action-buttons">
+		                    <a {{action 'executeScript' script on="click"}} role="button">
+		                      <span class="glyphicon glyphicon-step-forward"></span>
+		                    </a>
+		                  </div>
+		                  <div class="checkbox">
+		                    <label>
+		                      {{script.Filename}}
+		                    </label>
+		                  </div>
+		                  <div class="pull-right action-buttons">
+		                    <a {{action "openEditModal" script on="click"}} role="button">
+		                      <span class="glyphicon glyphicon-pencil"></span>
+		                    </a>
+		                    <a {{action 'showDeleteDialog' script on="click"}} role="button">
+		                      <span class="glyphicon glyphicon-trash"></span>
+		                    </a>
+		                  </div>
+                  </li>
+                {{/unless}}    
               {{else}}
-                You haven't saved any scripts
+	                You haven't saved any scripts
               {{/each}}
             </ul>
           </div>
@@ -92,6 +94,38 @@
     <div id="section2">
       <h3>Selection of pre-written scripts for experiments</h3>
       <hr class="style1">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="panel-body">
+            <ul id="myCodeList" class="list-group">
+              {{#each model as |script|}}
+                {{#if script.readonly}}
+                  <li class="list-group-item">
+                    <div class="pull-left action-buttons">
+                      <a {{action 'executeScriptByFilename' script on="click"}} role="button">
+                        <span class="glyphicon glyphicon-step-forward"></span>
+                      </a>
+                    </div>
+                    <div class="checkbox">
+                      <label>
+                        {{script.Filename}}
+                      </label>
+                    </div>
+                    <div class="pull-right action-buttons">
+                      <a {{action "openViewModal" script on="click"}} role="button">
+                        <span class="glyphicon glyphicon-eye-open"></span>
+                      </a>
+                    </div>
+                  </li>
+                {{/if}}    
+              {{else}}
+                  No example scripts available
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      </div>
+
     </div>
 
     <div id="section3">

--- a/frontend/app/templates/user-home.hbs
+++ b/frontend/app/templates/user-home.hbs
@@ -63,7 +63,7 @@
                 {{#unless script.readonly}}
                   <li class="list-group-item">
 		                  <div class="pull-left action-buttons">
-		                    <a {{action 'executeScript' script on="click"}} role="button">
+		                    <a {{action 'executeScript' script "Id" on="click"}} role="button">
 		                      <span class="glyphicon glyphicon-step-forward"></span>
 		                    </a>
 		                  </div>
@@ -102,7 +102,7 @@
                 {{#if script.readonly}}
                   <li class="list-group-item">
                     <div class="pull-left action-buttons">
-                      <a {{action 'executeScriptByFilename' script on="click"}} role="button">
+                      <a {{action 'executeScript' script "Filename" on="click"}} role="button">
                         <span class="glyphicon glyphicon-step-forward"></span>
                       </a>
                     </div>
@@ -112,7 +112,7 @@
                       </label>
                     </div>
                     <div class="pull-right action-buttons">
-                      <a {{action "openViewModal" script on="click"}} role="button">
+                      <a {{action 'openViewModal' script on="click"}} role="button">
                         <span class="glyphicon glyphicon-eye-open"></span>
                       </a>
                     </div>
@@ -204,6 +204,34 @@
     </div>
   </div>
 </div>
+
+
+<div class="modal" id="viewModal" tabindex="-1" role="dialog" aria-labelledby="viewModalLabel" aria-hidden="true">
+  <div class="modal-dialog-full">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title" id="viewModalLabel">{{viewModalTitle}}</h4>
+      </div>
+
+      <div class="modal-body">
+        <form>
+          <div class="form-group">
+            <form id="contentForm" class="form-horizontal">
+              {{ember-ace lines=30  theme="ace/theme/cobalt" mode="ace/mode/python" value=viewContents aceInit=viewAceInit}}
+              <button type="button" class="btn btn-default btn-primary" data-dismiss="modal">Close</button>
+            </form>
+          </div>
+        </form>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+
+
 
 
 <div class="modal" id="runModal" tabindex="-1" role="dialog" aria-labelledby="runModalLabel" aria-hidden="true">


### PR DESCRIPTION
+ Created a backend directory to store common example scripts
+ added getCommonScripts, getScriptsByFilename, runScriptByFilename API methods.
+ Modified user-home model to load and display a list of these common scripts

![psl_virt_common_script_list](https://user-images.githubusercontent.com/6078658/29738880-4db0c530-8a4d-11e7-8690-5d48e6171082.png)

Fixes #75 , WIP #76 